### PR TITLE
Fix colon in attribute key name has been treat as xml namespace prefix.

### DIFF
--- a/src/MagicChunks.Tests/Documents/XmlDocumentTests.cs
+++ b/src/MagicChunks.Tests/Documents/XmlDocumentTests.cs
@@ -648,5 +648,37 @@ namespace MagicChunks.Tests.Documents
   </connectionStrings>
 </configuration>", result, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
         }
+
+        [Fact]
+        public void TransformWithColonInAttributeName()
+        {
+            // Arrange
+            var document = new XmlDocument(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <appSettings>
+    <add key=""Auth:Environment"" value=""Testing"" />
+    <add key=""Auth:Credential"" value=""abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"" />
+    <add key=""Auth:Type"" value=""Basic"" />
+  </appSettings>
+</configuration>");
+            
+            document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key = 'Auth:Environment']", "@value" }, "Production");
+            document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key=\"Auth:Credential\"]", "@value" }, "XqoL6MXqOPeGTxXrJsQA7gK5cXLvnlSYJUtAwFWbRo7GDkbsSu");
+            document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key=\"Auth:Type\"]", "@value" }, "Bearer");
+
+            var result = document.ToString();
+
+
+            // Assert
+            Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <appSettings>
+    <add key=""Auth:Environment"" value=""Production"" />
+    <add key=""Auth:Credential"" value=""XqoL6MXqOPeGTxXrJsQA7gK5cXLvnlSYJUtAwFWbRo7GDkbsSu"" />
+    <add key=""Auth:Type"" value=""Bearer"" />
+  </appSettings>
+</configuration>", result, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        }
+
     }
 }

--- a/src/MagicChunks.Tests/Documents/XmlDocumentTests.cs
+++ b/src/MagicChunks.Tests/Documents/XmlDocumentTests.cs
@@ -659,12 +659,14 @@ namespace MagicChunks.Tests.Documents
     <add key=""Auth:Environment"" value=""Testing"" />
     <add key=""Auth:Credential"" value=""abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"" />
     <add key=""Auth:Type"" value=""Basic"" />
+    <add key=""Auth:Provider:Name"" value=""Name"" />
   </appSettings>
 </configuration>");
             
             document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key = 'Auth:Environment']", "@value" }, "Production");
             document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key=\"Auth:Credential\"]", "@value" }, "XqoL6MXqOPeGTxXrJsQA7gK5cXLvnlSYJUtAwFWbRo7GDkbsSu");
             document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key=\"Auth:Type\"]", "@value" }, "Bearer");
+            document.ReplaceKey(new[] { "configuration", "appSettings", "add[@key=\"Auth:Provider:Name\"]", "@value" }, "ABC");
 
             var result = document.ToString();
 
@@ -676,6 +678,7 @@ namespace MagicChunks.Tests.Documents
     <add key=""Auth:Environment"" value=""Production"" />
     <add key=""Auth:Credential"" value=""XqoL6MXqOPeGTxXrJsQA7gK5cXLvnlSYJUtAwFWbRo7GDkbsSu"" />
     <add key=""Auth:Type"" value=""Bearer"" />
+    <add key=""Auth:Provider:Name"" value=""ABC"" />
   </appSettings>
 </configuration>", result, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
         }

--- a/src/MagicChunks/Helpers/XmlExtensions.cs
+++ b/src/MagicChunks/Helpers/XmlExtensions.cs
@@ -43,7 +43,7 @@ namespace MagicChunks.Helpers
                 result = XName.Get(name, defaultNamespace);
             else
             {
-                var attributeNameParts = name.Split(':');
+                var attributeNameParts = name.Split(':');                
                 var attributeNamespace = element.GetNamespaceOfPrefix(attributeNameParts[0]);
                 if (attributeNamespace != null)
                     result = XName.Get(attributeNameParts[1], attributeNamespace.NamespaceName);
@@ -58,8 +58,10 @@ namespace MagicChunks.Helpers
         {
             if (!NodeIndexEndingRegex.IsMatch(name))
             {
+                bool isElementNameWithNamespace = name.IndexOf(':') > 0 && !(name.Split(':')[0].Contains("'") || (name.Split(':')[0].Contains(@"""")));
+
                 return source?.Elements()
-                    .FirstOrDefault(e => name.IndexOf(':') == -1 ?
+                    .FirstOrDefault(e => !isElementNameWithNamespace ?
                                             String.Compare(e.Name.LocalName, name, StringComparison.OrdinalIgnoreCase) == 0 :
                                             e.Name == name.GetNameWithNamespace(source, String.Empty));
             }


### PR DESCRIPTION
This will check that after split the colon to get element name and namespace, if the name contain quote, it will not treat this element as an element with namespace

Fix #34 