### PR TITLE
Added handling of ":" in XML attribute names

### DIFF
--- a/src/MagicChunks.Tests/Core/TransformerTests.cs
+++ b/src/MagicChunks.Tests/Core/TransformerTests.cs
@@ -427,5 +427,49 @@ d: 4
             // Assert
             Assert.True(result.Message?.StartsWith("Unknown document type."));
         }
+
+        [Fact]
+        public void TransformXmlSpecial()
+        {
+            // Arrange
+
+            var transform = new TransformationCollection()
+            {
+                { "xml/a/item[@key = 'item2']", "5" },
+                { "xml/b/item[@key = 'item2']/@value", "7" },
+                { "xml/b/item[@key = 'test:item3']/@value", "8" },
+                { "xml/b/item[@key='test2:item3']/@value", "8" },
+            };
+
+
+            // Act
+
+            var transformer = new Transformer();
+            string result = transformer.Transform(new XmlDocument(@"<xml>
+<a>
+  <item key=""item1"">1</item>
+  <item key=""item2"">2</item>
+</a>
+<b>
+   <item key=""item1"" value=""1"">1</item>
+</b>
+</xml>"), transform);
+
+
+            // Assert
+
+            Assert.Equal(@"<xml>
+  <a>
+    <item key=""item1"">1</item>
+    <item key=""item2"">5</item>
+  </a>
+  <b>
+   <item key=""item1"" value=""1"">1</item>
+   <item key=""item2"" value=""7"" />
+   <item key=""test:item3"" value=""8"" />
+   <item key=""test2:item3"" value=""8"" />
+  </b>
+</xml>", result, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        }
     }
 }

--- a/src/MagicChunks.Tests/Documents/XmlDocumentTests.cs
+++ b/src/MagicChunks.Tests/Documents/XmlDocumentTests.cs
@@ -325,5 +325,28 @@ namespace MagicChunks.Tests.Documents
   </connectionStrings>
 </configuration>", result, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
         }
+
+        [Fact]
+        public void ValidateDoubleColumn()
+        {
+            // Arrange
+            XmlDocument document = new XmlDocument(@"<configuration>
+  <connectionStrings>
+    <add name=""api:Connection"" connectionString="""" />
+  </connectionStrings>
+</configuration>");
+
+            // Act
+            document.ReplaceKey(new[] { "configuration", "connectionStrings", "add[@name='api:Connection']", "@connectionString" }, @"metadata=res://*/Model.csdl|res://*/Model.ssdl|res://*/Model.msl;provider=System.Data.SqlClient;provider connection string=""data source=other-server\instance;initial catalog=database;integrated security=True;multipleactiveresultsets=True;""");
+
+            var result = document.ToString();
+
+            // Assert1
+            Assert.Equal(@"<configuration>
+  <connectionStrings>
+    <add name=""api:Connection"" connectionString=""metadata=res://*/Model.csdl|res://*/Model.ssdl|res://*/Model.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=other-server\instance;initial catalog=database;integrated security=True;multipleactiveresultsets=True;&quot;"" />
+  </connectionStrings>
+</configuration>", result, ignoreCase: true, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        }
     }
 }

--- a/src/MagicChunks/Helpers/XmlExtensions.cs
+++ b/src/MagicChunks/Helpers/XmlExtensions.cs
@@ -9,12 +9,14 @@ namespace MagicChunks.Helpers
     {
         public static XName GetNameWithNamespace(this string name, XElement element, string defaultNamespace)
         {
+            var preparedName = name.Split('[')[0];
+
             XName result;
-            if (name.Contains(':') == false)
-                result = XName.Get(name, defaultNamespace);
+            if (preparedName.Contains(':') == false)
+                result = XName.Get(preparedName, defaultNamespace);
             else
             {
-                var attributeNameParts = name.Split(':');
+                var attributeNameParts = preparedName.Split(':');
                 var attributeNamespace = element.GetNamespaceOfPrefix(attributeNameParts[0]);
                 if (attributeNamespace != null)
                     result = XName.Get(attributeNameParts[1], attributeNamespace.NamespaceName);


### PR DESCRIPTION
We use magic chunks localy, and we also use XML configuration namespaces within attribute values.

This fix allows for transforming configurations such as:
```
<configuration>
  <add key="domain:keyItem" value="someValue"/>
</configuration>
```
using transformation:
```
{
"configuration/add[@key='domain:keyItem']" : "someNewValue"
}
```
will get:
```
<configuration>
  <add key="domain:keyItem" value="someNewValue"/>
</configuration>
```