### PR TITLE
cake build 0.26.1 support

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -153,6 +153,7 @@ Task("Build")
 
         CopyFiles(paths.workingDirSolutionDir + "/MagicChunks" + "/bin/" + configuration + "/netstandard1.3/MagicChunks*.dll", paths.workingDirDotNet);
         CopyFiles(paths.workingDirSolutionDir + "/MagicChunks.Cake" + "/bin/" + configuration + "/netstandard1.6/MagicChunks.Cake.dll", paths.workingDirDotNet);
+        CopyFiles(paths.workingDirSolutionDir + "/MagicChunks.Cake" + "/bin/" + configuration + "/netstandard2.0/MagicChunks.Cake.dll", paths.workingDirDotNet);
         CopyFiles(paths.workingDirSolutionDir + "/MagicChunks/MSBuild/*.targets", paths.workingDirDotNet);
         CopyFiles(paths.workingDirSolutionDir + "/MagicChunks/Powershell/*.ps*", paths.workingDirDotNet);
     });
@@ -176,11 +177,13 @@ Task("PackNuget")
     .Does(() => {
         EnsureDirectoryExists(paths.workingDirNuget + "/netstandard1.3/MagicChunks");
         EnsureDirectoryExists(paths.workingDirNuget + "/netstandard1.6/MagicChunks");
-        
+        EnsureDirectoryExists(paths.workingDirNuget + "/netstandard2.0/MagicChunks");
+
         CopyFiles(resolveDirectoryPath(paths.workingDirSources + "/nuspecs") + "/*.nuspec", paths.workingDirNuget);
-        CopyFiles(paths.workingDirDotNet + "/**/*.*", paths.workingDirNuget + "/netstandard1.3/MagicChunks");
-        DeleteFile(paths.workingDirNuget + "/netstandard1.3/MagicChunks/MagicChunks.Cake.dll");
+        CopyFiles(paths.workingDirDotNet + "/**/*.*", paths.workingDirNuget + "/netstandard1.3/MagicChunks");        
         CopyFiles(paths.workingDirDotNet + "/**/*.*", paths.workingDirNuget + "/netstandard1.6/MagicChunks");
+        CopyFiles(paths.workingDirDotNet + "/**/*.*", paths.workingDirNuget + "/netstandard2.0/MagicChunks");
+        DeleteFile(paths.workingDirNuget + "/netstandard1.3/MagicChunks/MagicChunks.Cake.dll");        
 
         foreach (string file in System.IO.Directory.EnumerateFiles(paths.workingDirNuget, "*.nuspec"))
         {

--- a/nuspecs/MagicChunks.nuspec
+++ b/nuspecs/MagicChunks.nuspec
@@ -22,8 +22,11 @@
         <file src="netstandard1.3\MagicChunks\MagicChunks.targets" target="lib\netstandard1.3" />
         <file src="netstandard1.3\MagicChunks\MagicChunks.psm1" target="lib\netstandard1.3" />
         <file src="netstandard1.6\MagicChunks\MagicChunks.dll" target="lib\netstandard1.6" />
-        <file src="netstandard1.6\MagicChunks\MagicChunks.Cake.dll" target="lib\netstandard1.6" />
         <file src="netstandard1.6\MagicChunks\MagicChunks.targets" target="lib\netstandard1.6" />
         <file src="netstandard1.6\MagicChunks\MagicChunks.psm1" target="lib\netstandard1.6" />
+        <file src="netstandard2.0\MagicChunks\MagicChunks.dll" target="lib\netstandard2.0" />
+        <file src="netstandard2.0\MagicChunks\MagicChunks.Cake.dll" target="lib\netstandard2.0" />
+        <file src="netstandard2.0\MagicChunks\MagicChunks.targets" target="lib\netstandard2.0" />
+        <file src="netstandard2.0\MagicChunks\MagicChunks.psm1" target="lib\netstandard2.0" />
     </files>
 </package>

--- a/src/MagicChunks.Cake/MagicChunks.Cake.csproj
+++ b/src/MagicChunks.Cake/MagicChunks.Cake.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Sergey Zwezdin</Authors>
     <Company />
     <Product>Magic Chunks</Product>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.23.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MagicChunks/MagicChunks.csproj
+++ b/src/MagicChunks/MagicChunks.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Authors>Sergey Zwezdin</Authors>
     <Company />
@@ -15,7 +15,10 @@
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Configuration, Transform, JSON, XML, YAML, YML, web.config, app.config, appsetings.json</PackageTags>
   </PropertyGroup>
-
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" Version="15.5.180" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/MagicChunks/VSTS/_build.ps1
+++ b/src/MagicChunks/VSTS/_build.ps1
@@ -1,2 +1,3 @@
-﻿npm i -g tfx-cli
+﻿npm i npm@latest -g 
+npm i -g tfx-cli
 tfx extension create --manifest-globs vss-extension.json


### PR DESCRIPTION
- Updates the solution to support multi targeted output, including .net standard 2.0 required for cake build.
- Hopefully fixes problems reported at https://github.com/cake-contrib/Home/blob/master/Audit_for_Cake_0.26.0.md
- Unsure how the cake.build ILRepack works.
- No unit tests added, but https://github.com/cake-contrib/Cake.FileHelpers/tree/master/Cake.FileHelpers.Tests includes an interesting pattern that might be followed to ensure everything behaves.
- Closes #58.