### PR TITLE
Add support for forward slash in attribute value

### DIFF
--- a/src/MagicChunks.Tests/Core/TransformationKeyTests.cs
+++ b/src/MagicChunks.Tests/Core/TransformationKeyTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using MagicChunks.Core;
+using Xunit;
+
+namespace MagicChunks.Tests.Core
+{
+    public class TransformationKeyTests
+    {
+        [InlineData("xml", TransformationKeyType.Replace, new [] { "xml" })]
+        [InlineData("xml/a/y", TransformationKeyType.Replace, new [] { "xml", "a", "y" })]
+        [InlineData("xml/a/@y", TransformationKeyType.Replace, new [] { "xml", "a", "@y" })]
+        [InlineData("xml/a[1]", TransformationKeyType.Replace, new [] { "xml", "a[1]" })]
+        [InlineData("xml/b[@key=\"item\"]", TransformationKeyType.Replace, new[] { "xml", "b[@key=\"item\"]" })]
+        [InlineData("xml/b[@key='item/subsetting']/val", TransformationKeyType.Replace, new[] { "xml", "b[@key='item/subsetting']", "val" })]
+        [InlineData("items[@i='a/b']/data", TransformationKeyType.Replace, new[] { "items[@i='a/b']", "data" })]
+        [InlineData("#xml/a", TransformationKeyType.Remove, new [] { "xml", "a" })]
+        [InlineData("xml/items[]`1", TransformationKeyType.AddToArray, new[] { "xml", "items" })]
+        [InlineData("xml/items[]`2", TransformationKeyType.AddToArray, new[] { "xml", "items" })]
+        [Theory]
+        public void Parse(string key, TransformationKeyType type, string[] path)
+        {
+            // Act
+
+            var transformationKey = new TransformationKey(key);
+
+            // Assert
+
+            Assert.Equal(type, transformationKey.Type);
+            Assert.Equal(path.AsEnumerable(), transformationKey.Path);
+        }
+    }
+}

--- a/src/MagicChunks.Tests/Core/TransformerTests.cs
+++ b/src/MagicChunks.Tests/Core/TransformerTests.cs
@@ -134,6 +134,7 @@ namespace MagicChunks.Tests.Core
                 { "#items[0]", "" },
                 { "#items[@i='1']/x", "" },
                 { "items[@i='3']", "{ y: '20' }" },
+                { "items[@i='a/b']/data", "2" },
                 { "items[0]", "{ x: '40' }" },
             };
 
@@ -147,6 +148,7 @@ namespace MagicChunks.Tests.Core
         { 'i': 1, data: 'BB', x: '25' },
         { 'i': 2, data: 'CC' },
         { 'i': 3, data: 'DD' },
+        { 'i': 'a/b', data: 'EE' }
     ],
     'b': '2',
     'c': '3'
@@ -166,6 +168,10 @@ namespace MagicChunks.Tests.Core
     },
     {
       ""y"": ""20""
+    },
+    {
+      ""i"": ""a/b"",
+      ""data"": ""2""
     }
   ],
   ""b"": ""2"",
@@ -192,6 +198,7 @@ namespace MagicChunks.Tests.Core
                 { "xml/e/item[@key=\"item3\"]", "6" },
                 { "xml/f/item[@key = 'item2']/val", "7" },
                 { "xml/f/item[@key=\"item3\"]/val", "8" },
+                { "xml/f/item[@key='item3/subsetting']/val", "9" },
                 { "xml/d", "4" },
                 { "#xml/g", "" },
                 { "xml/items[]`1", "<val>1</val>" },
@@ -224,6 +231,9 @@ namespace MagicChunks.Tests.Core
   </item>
   <item key=""item3"">
     <val>3</val>
+  </item>
+  <item key=""item3/subsetting"">
+    <val></val>
   </item>
 </f>
 <g>
@@ -267,6 +277,9 @@ namespace MagicChunks.Tests.Core
     <item key=""item3"">
       <val>8</val>
     </item>
+  <item key=""item3/subsetting"">
+    <val>9</val>
+  </item>
   </f>
   <items>
     <val>1</val>

--- a/src/MagicChunks/Core/TransformationKey.cs
+++ b/src/MagicChunks/Core/TransformationKey.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MagicChunks.Core
+{
+    public enum TransformationKeyType
+    {
+        Replace,
+        AddToArray,
+        Remove
+    }
+
+    public class TransformationKey
+    {
+        private static readonly Regex RemoveEndingRegex = new Regex(@"\`\d+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex RemoveArrayEndingRegex = new Regex(@"\[\]$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly Regex KeyChunkRegex = new Regex(@"\s?([^\/\[\]]+)(\[.+\])*\s?", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+
+        public TransformationKey(string transformationKey)
+        {
+            if (String.IsNullOrWhiteSpace(transformationKey))
+                throw new ArgumentException("Transformation key is empty.", nameof(transformationKey));
+
+            if (transformationKey.StartsWith("#"))
+            {
+                Type = TransformationKeyType.Remove;
+                Path = Split(transformationKey.TrimStart('#'));
+                return;
+            }
+
+            if (RemoveEndingRegex.Replace(transformationKey, String.Empty).EndsWith("[]"))
+            {
+                Type = TransformationKeyType.AddToArray;
+                Path = Split(RemoveArrayEndingRegex.Replace(RemoveEndingRegex.Replace(transformationKey, String.Empty), String.Empty));
+                return;
+            }
+
+            Type = TransformationKeyType.Replace;
+            Path = Split(transformationKey);
+            
+        }
+
+        public TransformationKeyType Type { get; }
+
+        public string[] Path { get; }
+
+        public static string[] Split(string trasformationKey)
+        {
+            var splits = KeyChunkRegex.Matches(trasformationKey)
+                .Cast<Match>().Select(x => x.Value.Trim());
+
+            return splits.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
I faced a problem with the following transformation for app.config file:
```
{
    "configuration/appSettings/add[@key='NServiceBus/License']/@value": "$(NServiceBusLicense)"
}
```
The issue was in ``.Split("/")`` method call, that didn't respect boundaries of ``[@attribute='value']`` clause.

Since we recently started using Azure DevOps we choose this task library for deployment transformation, but since we use NServiceBus with dozens of services, we have to use workarounds for this particular setting. 
