### PR TITLE
allows for explicitly typed xml encoded values to be referenced in xm…

### DIFF
--- a/src/MagicChunks/Documents/XmlDocument.cs
+++ b/src/MagicChunks/Documents/XmlDocument.cs
@@ -184,7 +184,7 @@ namespace MagicChunks.Documents
 
             if (targetElement.StartsWith("@") == true)
             {   // Attriubte update
-                current.SetAttributeValue(targetElement.TrimStart('@').GetNameWithNamespace(current, String.Empty), value.Replace("&quot;", @"""").Replace("&lt;", @"<").Replace("&gt;", @">"));
+                current.SetAttributeValue(targetElement.TrimStart('@').GetNameWithNamespace(current, String.Empty), value.Replace("&quot;", @"""").Replace("&lt;", @"<").Replace("&gt;", @">").Replace("&amp;quot;", @"&quot;").Replace("&amp;lt;", @"&lt;").Replace("&amp;gt;", @"&gt;"));
             }
             else if (!attributeFilterMatch.Success)
             {   // Property update


### PR DESCRIPTION
Simply replaces double escaped xml with the actual escaped xml (such that you can have &lt; rather than &amp;lt; in an xml config. #92 