### PR TITLE
Fix breaking build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -105,6 +105,10 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+### Cake ###
+tools/*
+!tools/packages.config
 
 artifacts/
 src/.vs

--- a/src/MagicChunks/VSTS/_build.ps1
+++ b/src/MagicChunks/VSTS/_build.ps1
@@ -1,3 +1,0 @@
-﻿npm i npm@latest -g 
-npm i -g tfx-cli
-tfx extension create --manifest-globs vss-extension.json


### PR DESCRIPTION
Currently build is failing because `npm install` has a warning which is written to StdErr. The `npm install` call is done in a PowerShell script called from the Cake build script where it's not possible to handle the error in the Cake script. I therefore have changed the Cake script to directly call npm and tfx so that we can handle the warning there. 