### PR TITLE
Integrate logic from AppVeyor into build script

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -1,9 +1,13 @@
+#addin nuget:?package=Cake.Git&version=0.22.0
 #addin nuget:?package=Cake.Npm&version=0.17.0
 #addin nuget:?package=Cake.Tfx&version=0.9.1
 
 #addin nuget:?package=Newtonsoft.Json&version=12.0.3
 
 #tool nuget:?package=ILRepack&version=2.0.18
+
+using System.Text.RegularExpressions;
+using System.Linq;
 
 // Helpers
 
@@ -14,8 +18,16 @@ Func<string, string> resolveDirectoryPath = (string source) => MakeAbsolute(Dire
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
-var version = Argument("versionnumber", "0.0.0");
-var versionbuild = Argument("versionbuild", "0");
+var versionbuild = EnvironmentVariable("appveyor_build_version", "0");
+
+var tags = GitTags(resolveDirectoryPath("./../"));
+var lastTag = tags.Last();
+var matches = Regex.Matches(lastTag.ToString(), "v([0-9\\.]+)", RegexOptions.IgnoreCase);
+var version = "0.0.0";
+if (matches[0].Success && matches[0].Groups.Count > 1)
+{
+    version = matches[0].Groups[1].Value;
+}
 
 // Variables
 


### PR DESCRIPTION
Integrate logic from AppVeyor into build script to have only a single call to build script left on CI server which allows to move more easily to other CI servers in the future (#102).

Once this is merged we can remove the additional PowerShell code from AppVeyor configuration and just call the build script.

It currently copies logic from AppVeyor into build script. Rewriting of the versioning can be done in a later PR (#109).