### PR TITLE
(GH-78) removed the unconditional replacement of \ with \\

### DIFF
--- a/src/MagicChunks/VSTS/MagicChunks/transform.ps1
+++ b/src/MagicChunks/VSTS/MagicChunks/transform.ps1
@@ -55,7 +55,7 @@ try {
         }
     }
 
-    foreach($t in ($transformations.Replace("\", "\\") | ConvertFrom-Json).psobject.properties) {
+    foreach($t in ($transformations | ConvertFrom-Json).psobject.properties) {
         Write-Host "Transformation found: $($t.name): $($t.value)"
         $transforms.Add($t.name, $t.value)
     }


### PR DESCRIPTION
When parsing the input for the DevOps task, every occurrence
of "\" was replaced by "\\" - probably in the assumption that
every JSON specified as transformation will always be
incorrectly escaped.

This will fix #78, however this will also break pipelines for everyone who is currently replacing paths using technically non-valid json.